### PR TITLE
Fixed multiple calls for home page products

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,8 @@
 import { Carousel } from 'components/carousel';
 import { ThreeItemGrid } from 'components/grid/three-items';
 import Footer from 'components/layout/footer';
+import { getCollectionProducts } from 'lib/sfdc';
+import { Product } from 'lib/sfdc/types';
 
 export const metadata = {
   description: 'High-performance ecommerce store built with Next.js, Vercel, and Salesforce.',
@@ -10,10 +12,13 @@ export const metadata = {
 };
 
 export default async function HomePage() {
+  const products: Product[] = await getCollectionProducts({
+    collection: 'hidden-homepage-featured-items'
+  });
   return (
     <>
-      <ThreeItemGrid />
-      <Carousel />
+      <ThreeItemGrid products={products}/>
+      <Carousel products={products}/>
       <Footer />
     </>
   );

--- a/components/carousel.tsx
+++ b/components/carousel.tsx
@@ -1,10 +1,13 @@
-import { getCollectionProducts } from 'lib/sfdc';
 import Link from 'next/link';
 import { GridTileImage } from './grid/tile';
+import { Product } from 'lib/sfdc/types';
 
-export async function Carousel() {
+type CarouselProducts = {
+  products: Product[];
+};
+
+export async function Carousel({ products }: CarouselProducts) {
   // Collections that start with `hidden-*` are hidden from the search page.
-  const products = await getCollectionProducts({ collection: 'hidden-homepage-carousel' });
 
   if (!products?.length) return null;
 

--- a/components/grid/three-items.tsx
+++ b/components/grid/three-items.tsx
@@ -1,7 +1,10 @@
 import { GridTileImage } from 'components/grid/tile';
-import { getCollectionProducts } from 'lib/sfdc';
 import type { Product } from 'lib/sfdc/types';
 import Link from 'next/link';
+
+type ThreeItemGridProducts = {
+  products: Product[];
+};
 
 function ThreeItemGridItem({
   item,
@@ -41,17 +44,14 @@ function ThreeItemGridItem({
   );
 }
 
-export async function ThreeItemGrid() {
-  // Collections that start with `hidden-*` are hidden from the search page.
-  const homepageItems = await getCollectionProducts({
-    collection: 'hidden-homepage-featured-items'
-  });
+export async function ThreeItemGrid({ products }: ThreeItemGridProducts) {
+  // Collections that start with `hidden-*` are hidden from the search pag
 
-  if (homepageItems == null) return null
+  if (products == null) return null
 
-  if (!homepageItems[0] || !homepageItems[1] || !homepageItems[2]) return null;
+  if (!products[0] || !products[1] || !products[2]) return null;
 
-  const [firstProduct, secondProduct, thirdProduct] = homepageItems;
+  const [firstProduct, secondProduct, thirdProduct] = products;
 
   return (
     <section className="mx-auto grid max-w-screen-2xl gap-4 px-4 pb-4 md:grid-cols-6 md:grid-rows-2 lg:max-h-[calc(100vh-200px)]">

--- a/lib/sfdc/index.ts
+++ b/lib/sfdc/index.ts
@@ -125,6 +125,7 @@ async function makeSfdcApiCall(endpoint: string, httpMethod: HttpMethod, body?: 
         Authorization: `Bearer ${authToken}`
       },
       body: body ? JSON.stringify(body) : null,
+      cache: 'force-cache'
     });
     if (!response.ok) {
       // throw new Error(`HTTP error! Status: ${response.status}`);


### PR DESCRIPTION
Fixed multiple calls for home page products.
The home page was having two sections.
- Feature Itesm (Products) (hidden-homepage-featured-items)
- Products carousel (hidden-homepage-carousel)

As we don't have any such products as part of commerc store, hence it was calling the same get products and pricing APIs twice. So, moved the logic to get the products to the Home page app/page.tsx and then passing these products to the components/grid/three-items.tsx and components/carousel.tsx pages to render the details.