### PR TITLE
Added manual delay on Add to Cart

### DIFF
--- a/lib/sfdc/index.ts
+++ b/lib/sfdc/index.ts
@@ -163,6 +163,10 @@ export async function addToCart(
     type: lines.type,
   };
   const response = await makeSfdcApiCall(endpoint, HttpMethod.POST, requestBody);
+  
+  // Add a 2-second delay
+  await new Promise(resolve => setTimeout(resolve, 2000));
+
   return mapCart(response);
 }
 


### PR DESCRIPTION
Added 2 sec delay on Add to Cart, as the it takes few seconds to mark the add to cart completed.
This was added becuase, as per the current flow, after adding the item to cart, UI triggres all the pages to reload causing the get cart details API to be called immediately , hence causing the issue on the cart.